### PR TITLE
Improve styles for upcoming coding challenges.

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -1,5 +1,7 @@
 const path = require("path");
 
+const TS1208 = "TS1208";
+
 module.exports = {
   // Configuration for React app customization
   // Currently minimal setup - can be extended as needed
@@ -11,6 +13,18 @@ module.exports = {
       "@": path.resolve(__dirname, "src"),
     },
     configure: (webpackConfig) => {
+      // Allow interviews with standalone TypeScript files.
+      const typeChecker = webpackConfig.plugins.find(
+        (plugin) => plugin.constructor.name === "ForkTsCheckerWebpackPlugin"
+      );
+
+      if (typeChecker) {
+        typeChecker.options.issue.exclude = [
+          ...(typeChecker.options.issue.exclude || []),
+          { origin: "typescript", code: TS1208 },
+        ];
+      }
+
       webpackConfig.resolve.symlinks = false;
       webpackConfig.watchOptions = {
         ...webpackConfig.watchOptions,

--- a/src/components/Instructions.css
+++ b/src/components/Instructions.css
@@ -210,24 +210,16 @@
 }
 
 .markdown-content code {
-  background: #505050;
-  color: #e2e8f0;
+  background: #f1f5f9;
+  color: #475569;
   padding: 2px 6px;
   border-radius: 4px;
   font-family: "Monaco", "Menlo", "Consolas", "Courier New", monospace;
   font-size: 0.85em;
-  border: 1px solid #606060;
+  border: 1px solid #cbd5e1;
   font-weight: 500;
 }
 
-/* Better contrast for light mode */
-:root .markdown-content code {
-  background: #f1f5f9;
-  color: #475569;
-  border: 1px solid #cbd5e1;
-}
-
-/* Ensure good contrast for dark mode */
 .dark .markdown-content code {
   background: #4a5568;
   color: #f7fafc;
@@ -235,17 +227,23 @@
 }
 
 .markdown-content pre {
-  background: #1a202c;
-  /* color: #e2e8f0; */
+  background: #f8fafc;
+  color: #1e293b;
   padding: 16px;
   border-radius: 8px;
   overflow-x: auto;
   margin: 16px 0;
-  border: 1px solid #2d3748;
+  border: 1px solid #cbd5e1;
   white-space: pre;
   font-family: "Monaco", "Menlo", "Consolas", "Courier New", monospace;
   font-size: 0.85rem;
   line-height: 1.4;
+}
+
+.dark .markdown-content pre {
+  background: #1a202c;
+  color: #e2e8f0;
+  border: 1px solid #2d3748;
 }
 
 .markdown-content pre code {

--- a/src/components/InterviewShell.tsx
+++ b/src/components/InterviewShell.tsx
@@ -35,6 +35,7 @@ interface InterviewShellProps {
 const ResizableSidebarContent: React.FC<{
   pattern: InterviewPattern;
   sidebarWidth: number;
+  fullWidth?: boolean;
   setSidebarWidth: (width: number) => void;
   isDragging: boolean;
   setIsDragging: (dragging: boolean) => void;
@@ -42,12 +43,30 @@ const ResizableSidebarContent: React.FC<{
 }> = ({
   pattern,
   sidebarWidth,
+  fullWidth = false,
   setSidebarWidth,
   isDragging,
   setIsDragging,
   handleResizeStart,
 }) => {
   const { open } = useSidebar();
+
+  if (fullWidth) {
+    return (
+      <div
+        className="relative h-full w-full max-w-4xl mx-auto"
+        style={{ "--sidebar-width": "100%" } as React.CSSProperties}
+      >
+        <Sidebar variant="inset" collapsible="none">
+          <SidebarContent className="overflow-hidden">
+            {pattern.readmes ? (
+              <Instructions readmes={pattern.readmes} onClose={() => {}} interviewId={pattern.id} />
+            ) : null}
+          </SidebarContent>
+        </Sidebar>
+      </div>
+    );
+  }
 
   // Don't show resize handle or apply custom width when sidebar is collapsed
   if (!open) {
@@ -189,6 +208,10 @@ const InterviewShell: React.FC<InterviewShellProps> = ({ pattern, onBack }) => {
   const PatternComponent = pattern.component;
   const isCodingChallenge = pattern.type === "coding-challenge";
   const isCodeReview = pattern.type === "code-review";
+  const hasPreview = isCodingChallenge
+    ? Boolean(pattern.implementationDetails)
+    : isCodeReview || Boolean(PatternComponent);
+  const isInstructionsOnly = Boolean(pattern.readmes?.length) && !hasPreview;
 
   return (
     <div
@@ -212,73 +235,79 @@ const InterviewShell: React.FC<InterviewShellProps> = ({ pattern, onBack }) => {
         </div>
       </header>
       <div className="flex-1 overflow-y-auto flex flex-col relative">
-        <SidebarProvider open={sidebarOpen} onOpenChange={handleSidebarOpenChange}>
+        <SidebarProvider
+          open={isInstructionsOnly || sidebarOpen}
+          onOpenChange={isInstructionsOnly ? () => {} : handleSidebarOpenChange}
+        >
           <ResizableSidebarContent
             pattern={pattern}
             sidebarWidth={sidebarWidth}
+            fullWidth={isInstructionsOnly}
             setSidebarWidth={setSidebarWidth}
             isDragging={isDragging}
             setIsDragging={setIsDragging}
             handleResizeStart={handleResizeStart}
           />
-          <SidebarInset className="flex-1 relative border flex overflow-hidden m-2 rounded-xl">
-            <header className="h-12 flex justify-between px-4 border-b relative">
-              <div className="flex items-center gap-4">
-                <SidebarTrigger />
-                <Separator
-                  orientation="vertical"
-                  className="data-[orientation=vertical]:h-4 bg-border"
-                />
-                <Breadcrumb>
-                  <BreadcrumbList>
-                    <BreadcrumbItem>
-                      <BreadcrumbLink asChild>
-                        <Button variant="ghost" size="sm" onClick={handleExit}>
-                          Home
-                        </Button>
-                      </BreadcrumbLink>
-                    </BreadcrumbItem>
-                    <BreadcrumbSeparator />
-                    <BreadcrumbItem>
-                      <BreadcrumbPage className="flex items-center gap-2 font-medium px-2">
-                        {pattern.name}
-                        <Badge
-                          variant="outline"
-                          className="px-1 text-muted-foreground"
-                        >
-                          v{pattern.version}
-                        </Badge>
-                      </BreadcrumbPage>
-                    </BreadcrumbItem>
-                  </BreadcrumbList>
-                </Breadcrumb>
-              </div>
-            </header>
-            <main className="bg-white flex-1 overflow-y-auto">
-              {!serverReady ? (
-                <div className="flex items-center justify-center h-full text-muted-foreground">
-                  Starting server...
+          {!isInstructionsOnly && (
+            <SidebarInset className="flex-1 relative border flex overflow-hidden m-2 rounded-xl">
+              <header className="h-12 flex justify-between px-4 border-b relative">
+                <div className="flex items-center gap-4">
+                  <SidebarTrigger />
+                  <Separator
+                    orientation="vertical"
+                    className="data-[orientation=vertical]:h-4 bg-border"
+                  />
+                  <Breadcrumb>
+                    <BreadcrumbList>
+                      <BreadcrumbItem>
+                        <BreadcrumbLink asChild>
+                          <Button variant="ghost" size="sm" onClick={handleExit}>
+                            Home
+                          </Button>
+                        </BreadcrumbLink>
+                      </BreadcrumbItem>
+                      <BreadcrumbSeparator />
+                      <BreadcrumbItem>
+                        <BreadcrumbPage className="flex items-center gap-2 font-medium px-2">
+                          {pattern.name}
+                          <Badge
+                            variant="outline"
+                            className="px-1 text-muted-foreground"
+                          >
+                            v{pattern.version}
+                          </Badge>
+                        </BreadcrumbPage>
+                      </BreadcrumbItem>
+                    </BreadcrumbList>
+                  </Breadcrumb>
                 </div>
-              ) : showInstructions && pattern.readmes ? (
-                <Instructions
-                  readmes={pattern.readmes}
-                  onClose={() => setShowInstructions(false)}
-                  interviewId={pattern.id}
-                />
-              ) : isCodingChallenge ? (
-                <CodingChallengeWrapper pattern={pattern} />
-              ) : isCodeReview ? (
-                <CodeReviewInterface pattern={pattern} />
-              ) : PatternComponent ? (
-                <PatternComponent />
-              ) : (
-                <div className="pattern-error">
-                  <h3>Pattern Error</h3>
-                  <p>No component found for this interview pattern.</p>
-                </div>
-              )}
-            </main>
-          </SidebarInset>
+              </header>
+              <main className="bg-white flex-1 overflow-y-auto">
+                {!serverReady ? (
+                  <div className="flex items-center justify-center h-full text-muted-foreground">
+                    Starting server...
+                  </div>
+                ) : showInstructions && pattern.readmes ? (
+                  <Instructions
+                    readmes={pattern.readmes}
+                    onClose={() => setShowInstructions(false)}
+                    interviewId={pattern.id}
+                  />
+                ) : isCodingChallenge ? (
+                  <CodingChallengeWrapper pattern={pattern} />
+                ) : isCodeReview ? (
+                  <CodeReviewInterface pattern={pattern} />
+                ) : PatternComponent ? (
+                  <PatternComponent />
+                ) : (
+                  <div className="pattern-error">
+                    <h3>Pattern Error</h3>
+                    <p>No component found for this interview pattern.</p>
+                  </div>
+                )}
+              </main>
+            </SidebarInset>
+          )}
         </SidebarProvider>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Add support for symlinked interview problems, including watch-mode updates and standalone TypeScript files.
- Give README-only challenges a focused, full-width instructions experience.
- Improve light and dark markdown code-block styling for clearer challenge instructions.

## Validation

- `npm run build`